### PR TITLE
Remove password encryption in config file

### DIFF
--- a/src/main/java/nuclibook/constants/C.java
+++ b/src/main/java/nuclibook/constants/C.java
@@ -18,13 +18,8 @@ public class C {
 		PropertiesConfiguration config = new PropertiesConfiguration("database.properties");
 		MYSQL_URI = config.getString("database.URI");
 		MYSQL_USERNAME = config.getString("database.user.name");
-		MYSQL_PASSWORD = decryptPassword(config.getString("database.user.password"));
+		MYSQL_PASSWORD = config.getString("database.user.password");
 		AUTOMATIC_TIMEOUT = config.getInt("security.automatictimeout");
 	}
 
-	private static String decryptPassword(String encryptedString) {
-		StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-		encryptor.setPassword("jasypt");
-		return encryptor.decrypt(encryptedString);
-	}
 }

--- a/src/main/resources/database.properties
+++ b/src/main/resources/database.properties
@@ -1,4 +1,4 @@
 database.URI=jdbc:mysql://bender.musalbas.com:3306/nuclibook
 database.user.name=nuclibook
-database.user.password=baehMHJR3qDMwz4WYD2ECq7opHjW8/8GaApmpZXAJYU=
+database.user.password=vTmQTKx8FYem32TL
 security.automatictimeout=600


### PR DESCRIPTION
Rationale:
- Obfuscating the password using symmetric encryption is futile because anyone who has access to the encrypted password can decrypt it as the decryption procedure is known and uses a known same encryption password ("jasypt").
- Therefore, it creates unnecessary additional inconvenience for the administrator that's managing the application with no added security, and there's currently no standard way to generate the encrypted password.
- It's standard to store the database password in this way; the server should be secured.
